### PR TITLE
refactor : 영화 앱의 데이터 동기화 작업 변경 및 목록 제한 기능

### DIFF
--- a/app/src/main/java/com/hwonchul/movie/data/local/dao/MovieDao.kt
+++ b/app/src/main/java/com/hwonchul/movie/data/local/dao/MovieDao.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.Flow
 
 @Dao
 interface MovieDao : BaseDao<MovieEntity> {
+
     @Query("SELECT * FROM ${MovieEntity.TABLE_NAME} WHERE type =:listType ORDER BY popularity DESC")
     fun findAllMovieOrderByPopularity(listType: MovieListType): Flow<List<MovieEntity>>
 
@@ -33,4 +34,7 @@ interface MovieDao : BaseDao<MovieEntity> {
             }
         }
     }
+
+    @Query("DELETE FROM ${MovieEntity.TABLE_NAME}")
+    suspend fun deleteAll()
 }

--- a/app/src/main/java/com/hwonchul/movie/data/repository/MovieRepositoryImpl.kt
+++ b/app/src/main/java/com/hwonchul/movie/data/repository/MovieRepositoryImpl.kt
@@ -46,6 +46,7 @@ class MovieRepositoryImpl @Inject constructor(
     }
 
     override suspend fun refreshForMovieList(listType: MovieListType) {
+        movieDao.deleteAll()
         val entities = api.getMovieList(listType).map { it.toEntity(listType) }
         movieDao.upsert(entities)
     }

--- a/app/src/main/java/com/hwonchul/movie/presentation/home/MovieAdapter.kt
+++ b/app/src/main/java/com/hwonchul/movie/presentation/home/MovieAdapter.kt
@@ -16,6 +16,7 @@ class MovieAdapter : RecyclerView.Adapter<MovieViewHolder>() {
     }
 
     private lateinit var listener: OnMovieDetailListener
+    private var limit = Integer.MAX_VALUE
 
     fun setOnMovieDetailListener(listener: OnMovieDetailListener) {
         this.listener = listener
@@ -25,6 +26,10 @@ class MovieAdapter : RecyclerView.Adapter<MovieViewHolder>() {
         items.clear()
         items.addAll(newItems)
         notifyDataSetChanged()
+    }
+
+    fun setLimit(limit: Int) {
+        this.limit = limit
     }
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MovieViewHolder {
@@ -40,7 +45,7 @@ class MovieAdapter : RecyclerView.Adapter<MovieViewHolder>() {
     }
 
     override fun getItemCount(): Int {
-        return items.size
+        return Math.min(items.size, limit)
     }
 
     inner class MovieViewHolder(

--- a/app/src/main/java/com/hwonchul/movie/util/BindingUtils.kt
+++ b/app/src/main/java/com/hwonchul/movie/util/BindingUtils.kt
@@ -63,6 +63,9 @@ object BindingUtils {
 
             // listener
             adapter.setOnMovieDetailListener(listener)
+
+            // limit
+            adapter.setLimit(10)
             listView.adapter = adapter
         }).apply { items?.let { setItems(it) } }
     }

--- a/app/src/main/res/layout/fragment_home.xml
+++ b/app/src/main/res/layout/fragment_home.xml
@@ -78,6 +78,7 @@
         </com.google.android.material.appbar.AppBarLayout>
 
         <androidx.core.widget.NestedScrollView
+            android:id="@+id/scroll_view"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             app:layout_behavior="@string/appbar_scrolling_view_behavior">
@@ -119,6 +120,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginTop="@dimen/space_large_16dp"
+                    android:minHeight="390dp"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"
                     app:layout_constraintTop_toBottomOf="@id/tv_popular_title"
@@ -159,6 +161,7 @@
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_marginVertical="@dimen/space_large_16dp"
+                    android:minHeight="390dp"
                     app:layout_constraintBottom_toBottomOf="parent"
                     app:layout_constraintEnd_toEndOf="@id/guideline_end"
                     app:layout_constraintStart_toStartOf="@id/guideline_start"


### PR DESCRIPTION
- 홈 화면에 있는 영화 리스트와 리스트 화면에 영화 리스트가 불일치하는 문제
  - 오래된 데이터 때문에 TMDB API 에서 제공하는 데이터와 불일치하는 것을 확인하였습니다.  이에 동기화 작업 전 Movie Entity 내 아이템을 비우는 것을 추가하였습니다.

- 홈 화면 리스트 개수 제한
  - 홈 화면은 카테고리의 대표 아이템을 한 눈에 볼 수 있게 하기 위한 컨셉이므로, 리스트 아이템을 10개로 제한하기로 하였습니다.